### PR TITLE
feat: #21 사용자 세팅·차단·닉네임 검색 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,7 @@ node_modules/
 dist/
 http/
 docs/
-/generated/prisma
-
-/generated/prisma
-
+scripts/test-all-apis*
 /generated/prisma
 
 #.cursor

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,8 +22,12 @@ model User {
   userCode   String   @unique
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
-  isKnocked  Boolean  @default(true)
-  isAgreed   Boolean  @default(false) // 약관 동의 완료 여부 (필수 약관 모두 동의 시 true)
+  isKnocked          Boolean  @default(true)
+  isAgreed           Boolean  @default(false) // 약관 동의 완료 여부 (필수 약관 모두 동의 시 true)
+  isRandomFeed       Boolean  @default(false) // 랜덤피드 허용 (내가 상대 랜덤 피드 보기)
+  isPublic           Boolean  @default(false) // 둘러보기 공개 (랜덤 상대에게 내 피드 보기 허용)
+  isRecommendPublic  Boolean  @default(false) // 추천친구 목록에 나를 공개
+  isRecommendEnabled Boolean  @default(false) // 유사 유저 추천 알고리즘 허용 (모멘트/버킷 카테고리 기준)
 
   buckets   Bucket[]
   moments   Moment[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,8 +32,10 @@ model User {
   buckets   Bucket[]
   moments   Moment[]
   userTerms UserTerm[]
-  following Follow[] @relation("UserFollowing")
-  followers Follow[] @relation("UserFollowers")
+  following      Follow[] @relation("UserFollowing")
+  followers      Follow[] @relation("UserFollowers")
+  blocking       Block[]  @relation("UserBlocking")
+  blockedByUsers Block[]  @relation("UserBlocked")
 
   @@map("user") // MongoDB 컬렉션 이름을 "user"로 지정
 }
@@ -80,6 +82,20 @@ model Follow {
 
   @@unique([followerID, followingID])
   @@map("follow")
+}
+
+model Block {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  blockerID String
+  blockedID String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  blocker User @relation("UserBlocking", fields: [blockerID], references: [id])
+  blocked User @relation("UserBlocked", fields: [blockedID], references: [id])
+
+  @@unique([blockerID, blockedID])
+  @@map("block")
 }
 
 model Bucket {

--- a/src/constants/userConstants.ts
+++ b/src/constants/userConstants.ts
@@ -9,3 +9,10 @@ export const USER_CODE_REGEX = /^#[A-Z0-9]{4}$/;
 
 // 추천친구 조회 최대 반환 수
 export const RECOMMEND_FRIENDS_LIMIT = 10;
+
+// 닉네임 검색 최소·최대 길이 (trim 후 기준)
+export const NICKNAME_SEARCH_MIN_LENGTH = 1;
+export const NICKNAME_SEARCH_MAX_LENGTH = 20;
+
+// 닉네임 검색 최대 반환 수
+export const NICKNAME_SEARCH_LIMIT = 20;

--- a/src/constants/userConstants.ts
+++ b/src/constants/userConstants.ts
@@ -6,3 +6,6 @@ export const DEFAULT_PROFILE_IMAGE = '기본이미지';
 
 // 유저코드 형식 (# + 대문자/숫자 4자리)
 export const USER_CODE_REGEX = /^#[A-Z0-9]{4}$/;
+
+// 추천친구 조회 최대 반환 수
+export const RECOMMEND_FRIENDS_LIMIT = 10;

--- a/src/controllers/blockController.ts
+++ b/src/controllers/blockController.ts
@@ -1,0 +1,28 @@
+import type { NextFunction, Request, Response } from 'express';
+import { blockUser, unblockUser } from '../services/blockService.js';
+
+// 사용자 차단
+export const block = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const blockerID = req.userId!;
+    const { userID: blockedID } = req.params as { userID: string };
+
+    const data = await blockUser({ blockerID, blockedID });
+    res.status(201).json({ message: '사용자 차단이 완료되었습니다.', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 사용자 차단 해제
+export const unblock = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const blockerID = req.userId!;
+    const { userID: blockedID } = req.params as { userID: string };
+
+    const data = await unblockUser({ blockerID, blockedID });
+    res.status(200).json({ message: '사용자 차단이 해제되었습니다.', data });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/recommendController.ts
+++ b/src/controllers/recommendController.ts
@@ -1,0 +1,17 @@
+import type { NextFunction, Request, Response } from 'express';
+import { getRecommendedFriends } from '../services/recommendService.js';
+
+// 추천친구 조회 컨트롤러
+export const getRecommendedFriendsController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const data = await getRecommendedFriends({ userID });
+    res.status(200).json({ message: '추천 친구 조회 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,6 +1,14 @@
 import type { Request, Response, NextFunction } from 'express';
 import { DEFAULT_PROFILE_IMAGE, NICKNAME_MAX_LENGTH } from '../constants/userConstants.js';
-import { getMyProfile, getUserProfile, searchUserByCode, updateMyProfile } from '../services/userService.js';
+import {
+  getMyProfile,
+  getUserProfile,
+  searchUserByCode,
+  toggleKnockPermission,
+  updateMyNickname,
+  updateMyProfile,
+  updateMyProfileImage,
+} from '../services/userService.js';
 
 // 내 프로필 조회 컨트롤러
 export const getMyProfileController = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -72,6 +80,78 @@ export const updateMyProfileController = async (req: Request, res: Response, nex
     });
 
     res.status(200).json({ message: '내 프로필 수정 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 프로필 이미지만 수정 컨트롤러
+export const updateMyProfileImageController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const { profile } = req.body as { profile?: unknown };
+
+    if (profile === undefined) {
+      res.status(400).json({ message: '프로필 이미지(profile)가 필요합니다.' });
+      return;
+    }
+    if (typeof profile !== 'string') {
+      res.status(400).json({ message: '프로필 이미지는 문자열이어야 합니다.' });
+      return;
+    }
+
+    const trimmed = profile.trim();
+    const profileValue = trimmed === '' ? DEFAULT_PROFILE_IMAGE : trimmed;
+
+    const data = await updateMyProfileImage({ userID, profile: profileValue });
+    res.status(200).json({ message: '프로필 이미지 수정 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 닉네임만 수정 컨트롤러
+export const updateMyNicknameController = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const { nickname } = req.body as { nickname?: unknown };
+
+    if (nickname === undefined) {
+      res.status(400).json({ message: '닉네임(nickname)이 필요합니다.' });
+      return;
+    }
+    if (typeof nickname !== 'string' || nickname.trim() === '') {
+      res.status(400).json({ message: '닉네임은 비어있지 않은 문자열이어야 합니다.' });
+      return;
+    }
+
+    const trimmed = nickname.trim();
+    if (trimmed.length > NICKNAME_MAX_LENGTH) {
+      res.status(400).json({ message: `닉네임은 ${NICKNAME_MAX_LENGTH}자 이내여야 합니다.` });
+      return;
+    }
+
+    const data = await updateMyNickname({ userID, nickname: trimmed });
+    res.status(200).json({ message: '닉네임 수정 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 노크 허용 여부 토글 컨트롤러
+export const toggleKnockPermissionController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const data = await toggleKnockPermission({ userID });
+    res.status(200).json({ message: '노크 허용 여부 변경 성공', data });
   } catch (err) {
     next(err);
   }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -4,6 +4,7 @@ import {
   getMyProfile,
   getUserProfile,
   searchUserByCode,
+  searchUsersByNickname,
   toggleKnockPermission,
   updateBrowsePublicSetting,
   updateMyNickname,
@@ -252,6 +253,27 @@ export const updateRecommendEnabledSettingController = async (
 
     const data = await updateRecommendEnabledSetting({ userID, isRecommendEnabled: isRecommendEnabledValue });
     res.status(200).json({ message: '추천친구 알고리즘 허용 여부 변경 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 닉네임으로 사용자 검색 컨트롤러
+export const searchUsersByNicknameController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const requestUserID = req.userId!;
+    const { nickname } = req.query as { nickname: string };
+
+    const data = await searchUsersByNickname({
+      nickname: nickname.trim(),
+      requestUserID,
+    });
+
+    res.status(200).json({ message: '닉네임 검색 성공', data });
   } catch (err) {
     next(err);
   }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -5,10 +5,30 @@ import {
   getUserProfile,
   searchUserByCode,
   toggleKnockPermission,
+  updateBrowsePublicSetting,
   updateMyNickname,
   updateMyProfile,
   updateMyProfileImage,
+  updateRandomFeedSetting,
+  updateRecommendEnabledSetting,
+  updateRecommendPublicSetting,
 } from '../services/userService.js';
+
+const parseRequiredBoolean = (
+  res: Response,
+  value: unknown,
+  fieldName: string,
+): boolean | undefined => {
+  if (value === undefined) {
+    res.status(400).json({ message: `${fieldName}이(가) 필요합니다.` });
+    return undefined;
+  }
+  if (typeof value !== 'boolean') {
+    res.status(400).json({ message: `${fieldName}는 boolean이어야 합니다.` });
+    return undefined;
+  }
+  return value;
+};
 
 // 내 프로필 조회 컨트롤러
 export const getMyProfileController = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -152,6 +172,86 @@ export const toggleKnockPermissionController = async (
     const userID = req.userId!;
     const data = await toggleKnockPermission({ userID });
     res.status(200).json({ message: '노크 허용 여부 변경 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 랜덤피드 허용 여부 수정 컨트롤러
+export const updateRandomFeedSettingController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const { isRandomFeed } = req.body as { isRandomFeed?: unknown };
+
+    const isRandomFeedValue = parseRequiredBoolean(res, isRandomFeed, 'isRandomFeed');
+    if (isRandomFeedValue === undefined) return;
+
+    const data = await updateRandomFeedSetting({ userID, isRandomFeed: isRandomFeedValue });
+    res.status(200).json({ message: '랜덤피드 허용 여부 변경 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 둘러보기 공개 여부 수정 컨트롤러
+export const updateBrowsePublicSettingController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const { isPublic } = req.body as { isPublic?: unknown };
+
+    const isPublicValue = parseRequiredBoolean(res, isPublic, 'isPublic');
+    if (isPublicValue === undefined) return;
+
+    const data = await updateBrowsePublicSetting({ userID, isPublic: isPublicValue });
+    res.status(200).json({ message: '둘러보기 공개 여부 변경 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 추천친구 공개 여부 수정 컨트롤러
+export const updateRecommendPublicSettingController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const { isRecommendPublic } = req.body as { isRecommendPublic?: unknown };
+
+    const isRecommendPublicValue = parseRequiredBoolean(res, isRecommendPublic, 'isRecommendPublic');
+    if (isRecommendPublicValue === undefined) return;
+
+    const data = await updateRecommendPublicSetting({ userID, isRecommendPublic: isRecommendPublicValue });
+    res.status(200).json({ message: '추천친구 공개 여부 변경 성공', data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 추천친구 알고리즘 허용 여부 수정 컨트롤러
+export const updateRecommendEnabledSettingController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userID = req.userId!;
+    const { isRecommendEnabled } = req.body as { isRecommendEnabled?: unknown };
+
+    const isRecommendEnabledValue = parseRequiredBoolean(res, isRecommendEnabled, 'isRecommendEnabled');
+    if (isRecommendEnabledValue === undefined) return;
+
+    const data = await updateRecommendEnabledSetting({ userID, isRecommendEnabled: isRecommendEnabledValue });
+    res.status(200).json({ message: '추천친구 알고리즘 허용 여부 변경 성공', data });
   } catch (err) {
     next(err);
   }

--- a/src/middlewares/userMiddleware.ts
+++ b/src/middlewares/userMiddleware.ts
@@ -1,5 +1,9 @@
 import type { NextFunction, Request, Response } from 'express';
-import { USER_CODE_REGEX } from '../constants/userConstants.js';
+import {
+  NICKNAME_SEARCH_MAX_LENGTH,
+  NICKNAME_SEARCH_MIN_LENGTH,
+  USER_CODE_REGEX,
+} from '../constants/userConstants.js';
 
 export const validateUserCodeQuery = (req: Request, res: Response, next: NextFunction): void => {
   const { userCode } = req.query;
@@ -16,6 +20,33 @@ export const validateUserCodeQuery = (req: Request, res: Response, next: NextFun
 
   if (!USER_CODE_REGEX.test(userCode.trim())) {
     res.status(400).json({ message: 'userCode는 #과 대문자/숫자 4자리 형식이어야 합니다.' });
+    return;
+  }
+
+  next();
+};
+
+export const validateNicknameQuery = (req: Request, res: Response, next: NextFunction): void => {
+  const { nickname } = req.query;
+
+  if (Array.isArray(nickname)) {
+    res.status(400).json({ message: 'nickname은 1개만 전달할 수 있습니다.' });
+    return;
+  }
+
+  if (typeof nickname !== 'string' || nickname.trim() === '') {
+    res.status(400).json({ message: 'nickname이 필요합니다.' });
+    return;
+  }
+
+  const trimmed = nickname.trim();
+  if (trimmed.length < NICKNAME_SEARCH_MIN_LENGTH) {
+    res.status(400).json({ message: `nickname은 ${NICKNAME_SEARCH_MIN_LENGTH}자 이상이어야 합니다.` });
+    return;
+  }
+
+  if (trimmed.length > NICKNAME_SEARCH_MAX_LENGTH) {
+    res.status(400).json({ message: `nickname은 ${NICKNAME_SEARCH_MAX_LENGTH}자 이내여야 합니다.` });
     return;
   }
 

--- a/src/routes/userRoute.ts
+++ b/src/routes/userRoute.ts
@@ -4,7 +4,10 @@ import {
   getMyProfileController,
   getUserProfileController,
   searchUserByCodeController,
+  toggleKnockPermissionController,
+  updateMyNicknameController,
   updateMyProfileController,
+  updateMyProfileImageController,
 } from '../controllers/userController.js';
 import { authenticate } from '../middlewares/authMiddleware.js';
 import { validateUserCodeQuery, validateUserIDParam } from '../middlewares/userMiddleware.js';
@@ -16,6 +19,15 @@ router.get('/me', authenticate, getMyProfileController);
 
 // PATCH  /api/v1/users/me 내 프로필 수정 (JWT 필요)
 router.patch('/me', authenticate, updateMyProfileController);
+
+// PATCH  /api/v1/users/me/profile 프로필 이미지만 수정 (JWT 필요)
+router.patch('/me/profile', authenticate, updateMyProfileImageController);
+
+// PATCH  /api/v1/users/me/nickname 닉네임만 수정 (JWT 필요)
+router.patch('/me/nickname', authenticate, updateMyNicknameController);
+
+// PATCH  /api/v1/users/me/knock 노크 허용 여부 토글 (JWT 필요)
+router.patch('/me/knock', authenticate, toggleKnockPermissionController);
 
 // GET    /api/v1/users/search?userCode=#AZ09 유저코드로 사용자 검색 (JWT 필요)
 router.get('/search', authenticate, validateUserCodeQuery, searchUserByCodeController);

--- a/src/routes/userRoute.ts
+++ b/src/routes/userRoute.ts
@@ -1,10 +1,12 @@
 import express from 'express';
+import { block, unblock } from '../controllers/blockController.js';
 import { follow, getFollowers, getFollowing, setFollowFavorite, unfollow } from '../controllers/followController.js';
 import { getRecommendedFriendsController } from '../controllers/recommendController.js';
 import {
   getMyProfileController,
   getUserProfileController,
   searchUserByCodeController,
+  searchUsersByNicknameController,
   toggleKnockPermissionController,
   updateBrowsePublicSettingController,
   updateMyNicknameController,
@@ -15,7 +17,7 @@ import {
   updateRecommendPublicSettingController,
 } from '../controllers/userController.js';
 import { authenticate } from '../middlewares/authMiddleware.js';
-import { validateUserCodeQuery, validateUserIDParam } from '../middlewares/userMiddleware.js';
+import { validateNicknameQuery, validateUserCodeQuery, validateUserIDParam } from '../middlewares/userMiddleware.js';
 
 const router = express.Router();
 
@@ -49,6 +51,9 @@ router.patch('/me/recommend/algorithm', authenticate, updateRecommendEnabledSett
 // GET    /api/v1/users/recommend 추천친구 조회 (JWT 필요)
 router.get('/recommend', authenticate, getRecommendedFriendsController);
 
+// GET    /api/v1/users/search/nickname?nickname= 닉네임으로 사용자 검색 (JWT 필요)
+router.get('/search/nickname', authenticate, validateNicknameQuery, searchUsersByNicknameController);
+
 // GET    /api/v1/users/search?userCode=#AZ09 유저코드로 사용자 검색 (JWT 필요)
 router.get('/search', authenticate, validateUserCodeQuery, searchUserByCodeController);
 
@@ -60,6 +65,12 @@ router.post('/follow/:userID', authenticate, validateUserIDParam, follow);
 
 // DELETE /api/v1/users/follow/:userID 팔로우 취소 (JWT 필요)
 router.delete('/follow/:userID', authenticate, validateUserIDParam, unfollow);
+
+// POST   /api/v1/users/block/:userID 사용자 차단 (JWT 필요)
+router.post('/block/:userID', authenticate, validateUserIDParam, block);
+
+// DELETE /api/v1/users/block/:userID 사용자 차단 해제 (JWT 필요)
+router.delete('/block/:userID', authenticate, validateUserIDParam, unblock);
 
 // PATCH  /api/v1/users/follow/favorite/:userID 팔로우 즐겨찾기 설정 (JWT 필요)
 router.patch('/follow/favorite/:userID', authenticate, validateUserIDParam, setFollowFavorite);

--- a/src/routes/userRoute.ts
+++ b/src/routes/userRoute.ts
@@ -1,13 +1,18 @@
 import express from 'express';
 import { follow, getFollowers, getFollowing, setFollowFavorite, unfollow } from '../controllers/followController.js';
+import { getRecommendedFriendsController } from '../controllers/recommendController.js';
 import {
   getMyProfileController,
   getUserProfileController,
   searchUserByCodeController,
   toggleKnockPermissionController,
+  updateBrowsePublicSettingController,
   updateMyNicknameController,
   updateMyProfileController,
   updateMyProfileImageController,
+  updateRandomFeedSettingController,
+  updateRecommendEnabledSettingController,
+  updateRecommendPublicSettingController,
 } from '../controllers/userController.js';
 import { authenticate } from '../middlewares/authMiddleware.js';
 import { validateUserCodeQuery, validateUserIDParam } from '../middlewares/userMiddleware.js';
@@ -28,6 +33,21 @@ router.patch('/me/nickname', authenticate, updateMyNicknameController);
 
 // PATCH  /api/v1/users/me/knock 노크 허용 여부 토글 (JWT 필요)
 router.patch('/me/knock', authenticate, toggleKnockPermissionController);
+
+// PATCH  /api/v1/users/me/browse/random-feed 랜덤피드 허용 여부 수정 (JWT 필요)
+router.patch('/me/browse/random-feed', authenticate, updateRandomFeedSettingController);
+
+// PATCH  /api/v1/users/me/browse/public 둘러보기 공개 여부 수정 (JWT 필요)
+router.patch('/me/browse/public', authenticate, updateBrowsePublicSettingController);
+
+// PATCH  /api/v1/users/me/recommend/public 추천친구 공개 여부 수정 (JWT 필요)
+router.patch('/me/recommend/public', authenticate, updateRecommendPublicSettingController);
+
+// PATCH  /api/v1/users/me/recommend/algorithm 추천친구 알고리즘 허용 여부 수정 (JWT 필요)
+router.patch('/me/recommend/algorithm', authenticate, updateRecommendEnabledSettingController);
+
+// GET    /api/v1/users/recommend 추천친구 조회 (JWT 필요)
+router.get('/recommend', authenticate, getRecommendedFriendsController);
 
 // GET    /api/v1/users/search?userCode=#AZ09 유저코드로 사용자 검색 (JWT 필요)
 router.get('/search', authenticate, validateUserCodeQuery, searchUserByCodeController);

--- a/src/services/blockService.ts
+++ b/src/services/blockService.ts
@@ -1,0 +1,80 @@
+import { prisma } from '../lib/prisma.js';
+import type { BlockUserParams } from '../types/block.types.js';
+import { FOLLOW_USER_SELECT } from '../types/follow.types.js';
+import { createError } from '../utils/createError.js';
+
+// 사용자 차단 (양방향 팔로우 관계 해제 포함)
+export const blockUser = async (params: BlockUserParams) => {
+  const { blockerID, blockedID } = params;
+
+  if (blockerID === blockedID) {
+    throw createError('자기 자신은 차단할 수 없습니다.', 400);
+  }
+
+  const [blocker, blocked, exists] = await Promise.all([
+    prisma.user.findUnique({ where: { id: blockerID }, select: { id: true } }),
+    prisma.user.findUnique({ where: { id: blockedID }, select: { id: true } }),
+    prisma.block.findUnique({
+      where: {
+        blockerID_blockedID: {
+          blockerID,
+          blockedID,
+        },
+      },
+      select: { id: true },
+    }),
+  ]);
+
+  if (!blocker) throw createError('로그인한 사용자를 찾을 수 없습니다.', 404);
+  if (!blocked) throw createError('차단할 사용자를 찾을 수 없습니다.', 404);
+  if (exists) throw createError('이미 차단한 사용자입니다.', 409);
+
+  return prisma.$transaction(async (tx) => {
+    await tx.follow.deleteMany({
+      where: {
+        OR: [
+          { followerID: blockerID, followingID: blockedID },
+          { followerID: blockedID, followingID: blockerID },
+        ],
+      },
+    });
+
+    return tx.block.create({
+      data: {
+        blockerID,
+        blockedID,
+      },
+      include: {
+        blocked: { select: FOLLOW_USER_SELECT },
+      },
+    });
+  });
+};
+
+// 사용자 차단 해제
+export const unblockUser = async (params: BlockUserParams) => {
+  const { blockerID, blockedID } = params;
+
+  if (blockerID === blockedID) {
+    throw createError('자기 자신은 차단 해제할 수 없습니다.', 400);
+  }
+
+  const block = await prisma.block.findUnique({
+    where: {
+      blockerID_blockedID: {
+        blockerID,
+        blockedID,
+      },
+    },
+    select: { id: true },
+  });
+
+  if (!block) throw createError('차단 관계를 찾을 수 없습니다.', 404);
+
+  return prisma.block.delete({
+    where: { id: block.id },
+    include: {
+      blocked: { select: FOLLOW_USER_SELECT },
+    },
+  });
+};

--- a/src/services/recommendService.ts
+++ b/src/services/recommendService.ts
@@ -1,5 +1,6 @@
 import { RECOMMEND_FRIENDS_LIMIT } from '../constants/userConstants.js';
 import { prisma } from '../lib/prisma.js';
+import { getBlockedUserIDSet } from './userService.js';
 import type { GetRecommendedFriendsParams } from '../types/user.types.js';
 import { RECOMMEND_USER_SELECT, type RecommendedFriend } from '../types/recommend.types.js';
 import { createError } from '../utils/createError.js';
@@ -37,7 +38,8 @@ export const getRecommendedFriends = async (params: GetRecommendedFriendsParams)
   ]);
 
   const myCategories = collectCategories(myBuckets);
-  const excludeUserIDs = new Set([userID, ...followingRows.map((row) => row.followingID)]);
+  const blockedIDs = await getBlockedUserIDSet(userID);
+  const excludeUserIDs = new Set([userID, ...followingRows.map((row) => row.followingID), ...blockedIDs]);
 
   const candidates = await prisma.user.findMany({
     where: {

--- a/src/services/recommendService.ts
+++ b/src/services/recommendService.ts
@@ -1,0 +1,84 @@
+import { RECOMMEND_FRIENDS_LIMIT } from '../constants/userConstants.js';
+import { prisma } from '../lib/prisma.js';
+import type { GetRecommendedFriendsParams } from '../types/user.types.js';
+import { RECOMMEND_USER_SELECT, type RecommendedFriend } from '../types/recommend.types.js';
+import { createError } from '../utils/createError.js';
+
+const collectCategories = (buckets: { category: string[] }[]): Set<string> => {
+  return new Set(buckets.flatMap((bucket) => bucket.category));
+};
+
+const getMatchedCategories = (myCategories: Set<string>, theirCategories: Set<string>): string[] => {
+  return [...myCategories].filter((category) => theirCategories.has(category));
+};
+
+// 추천친구 조회 (버킷 카테고리 유사도 기반)
+export const getRecommendedFriends = async (params: GetRecommendedFriendsParams): Promise<RecommendedFriend[]> => {
+  const { userID } = params;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userID },
+    select: { id: true, isRandomFeed: true, isRecommendEnabled: true },
+  });
+  if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
+  if (!user.isRandomFeed || !user.isRecommendEnabled) {
+    throw createError('랜덤피드 및 추천친구 알고리즘이 허용되어 있어야 추천 목록을 조회할 수 있습니다.', 403);
+  }
+
+  const [myBuckets, followingRows] = await Promise.all([
+    prisma.bucket.findMany({
+      where: { userID },
+      select: { category: true },
+    }),
+    prisma.follow.findMany({
+      where: { followerID: userID },
+      select: { followingID: true },
+    }),
+  ]);
+
+  const myCategories = collectCategories(myBuckets);
+  const excludeUserIDs = new Set([userID, ...followingRows.map((row) => row.followingID)]);
+
+  const candidates = await prisma.user.findMany({
+    where: {
+      isRecommendPublic: true,
+      id: { notIn: [...excludeUserIDs] },
+    },
+    select: RECOMMEND_USER_SELECT,
+  });
+
+  if (candidates.length === 0) return [];
+
+  const candidateIDs = candidates.map((candidate) => candidate.id);
+  const candidateBuckets = await prisma.bucket.findMany({
+    where: { userID: { in: candidateIDs } },
+    select: { userID: true, category: true },
+  });
+
+  const categoriesByUserID = new Map<string, Set<string>>();
+  for (const bucket of candidateBuckets) {
+    const existing = categoriesByUserID.get(bucket.userID) ?? new Set<string>();
+    for (const category of bucket.category) {
+      existing.add(category);
+    }
+    categoriesByUserID.set(bucket.userID, existing);
+  }
+
+  const scored: RecommendedFriend[] = candidates.map((candidate) => {
+    const theirCategories = categoriesByUserID.get(candidate.id) ?? new Set<string>();
+    const matchedCategories = getMatchedCategories(myCategories, theirCategories);
+
+    return {
+      ...candidate,
+      matchScore: matchedCategories.length,
+      matchedCategories,
+    };
+  });
+
+  return scored
+    .sort((a, b) => {
+      if (b.matchScore !== a.matchScore) return b.matchScore - a.matchScore;
+      return a.nickname.localeCompare(b.nickname);
+    })
+    .slice(0, RECOMMEND_FRIENDS_LIMIT);
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,10 +1,16 @@
+import {
+  NICKNAME_SEARCH_LIMIT,
+  NICKNAME_SEARCH_MAX_LENGTH,
+} from '../constants/userConstants.js';
 import { prisma } from '../lib/prisma.js';
 import {
+  type EnrichPublicUserParams,
   type GetUserProfileParams,
   USER_PROFILE_SELECT,
   USER_PUBLIC_PROFILE_SELECT,
   type GetMyProfileParams,
   type SearchUserByCodeParams,
+  type SearchUsersByNicknameParams,
   type ToggleKnockPermissionParams,
   type UpdateBrowsePublicSettingParams,
   type UpdateMyNicknameParams,
@@ -26,6 +32,83 @@ const assertRandomFeedEnabled = (isRandomFeed: boolean) => {
   if (!isRandomFeed) {
     throw createError('랜덤피드 허용이 켜져 있어야 이 설정을 변경할 수 있습니다.', 400);
   }
+};
+
+// 차단 관계(양방향) 사용자 ID 집합
+export const getBlockedUserIDSet = async (userID: string): Promise<Set<string>> => {
+  const blocks = await prisma.block.findMany({
+    where: {
+      OR: [{ blockerID: userID }, { blockedID: userID }],
+    },
+    select: { blockerID: true, blockedID: true },
+  });
+
+  const blockedIDs = new Set<string>();
+  for (const block of blocks) {
+    if (block.blockerID === userID) blockedIDs.add(block.blockedID);
+    if (block.blockedID === userID) blockedIDs.add(block.blockerID);
+  }
+  return blockedIDs;
+};
+
+const assertNotBlocked = async (requestUserID: string, targetUserID: string) => {
+  const block = await prisma.block.findFirst({
+    where: {
+      OR: [
+        { blockerID: requestUserID, blockedID: targetUserID },
+        { blockerID: targetUserID, blockedID: requestUserID },
+      ],
+    },
+    select: { id: true },
+  });
+  if (block) throw createError('차단된 사용자입니다.', 403);
+};
+
+// 공개 프로필 + 팔로우·차단 관계 정보
+export const enrichPublicUser = async (params: EnrichPublicUserParams) => {
+  const { user, requestUserID } = params;
+
+  const [followerCount, followingCount, following, blockedByMe, blockedMe] = await Promise.all([
+    prisma.follow.count({ where: { followingID: user.id } }),
+    prisma.follow.count({ where: { followerID: user.id } }),
+    prisma.follow.findUnique({
+      where: {
+        followerID_followingID: {
+          followerID: requestUserID,
+          followingID: user.id,
+        },
+      },
+      select: { id: true },
+    }),
+    prisma.block.findUnique({
+      where: {
+        blockerID_blockedID: {
+          blockerID: requestUserID,
+          blockedID: user.id,
+        },
+      },
+      select: { id: true },
+    }),
+    prisma.block.findUnique({
+      where: {
+        blockerID_blockedID: {
+          blockerID: user.id,
+          blockedID: requestUserID,
+        },
+      },
+      select: { id: true },
+    }),
+  ]);
+
+  return {
+    ...user,
+    followerCount,
+    followingCount,
+    isFollowing: Boolean(following),
+    isMe: user.id === requestUserID,
+    isBlocked: Boolean(blockedByMe),
+    isBlockedBy: Boolean(blockedMe),
+  };
 };
 
 // 내 프로필 조회
@@ -175,27 +258,34 @@ export const searchUserByCode = async (params: SearchUserByCodeParams) => {
 
   if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
 
-  const [followerCount, followingCount, following] = await Promise.all([
-    prisma.follow.count({ where: { followingID: user.id } }),
-    prisma.follow.count({ where: { followerID: user.id } }),
-    prisma.follow.findUnique({
-      where: {
-        followerID_followingID: {
-          followerID: requestUserID,
-          followingID: user.id,
-        },
-      },
-      select: { id: true },
-    }),
-  ]);
+  await assertNotBlocked(requestUserID, user.id);
 
-  return {
-    ...user,
-    followerCount,
-    followingCount,
-    isFollowing: Boolean(following),
-    isMe: user.id === requestUserID,
-  };
+  return enrichPublicUser({ user, requestUserID });
+};
+
+// 닉네임으로 사용자 검색 (부분 일치)
+export const searchUsersByNickname = async (params: SearchUsersByNicknameParams) => {
+  const { nickname, requestUserID } = params;
+  const trimmed = nickname.trim();
+
+  if (trimmed.length > NICKNAME_SEARCH_MAX_LENGTH) {
+    throw createError(`닉네임은 ${NICKNAME_SEARCH_MAX_LENGTH}자 이내로 검색해야 합니다.`, 400);
+  }
+
+  const blockedIDs = await getBlockedUserIDSet(requestUserID);
+  const excludeUserIDs = [requestUserID, ...blockedIDs];
+
+  const users = await prisma.user.findMany({
+    where: {
+      nickname: { contains: trimmed, mode: 'insensitive' },
+      id: { notIn: excludeUserIDs },
+    },
+    select: USER_PUBLIC_PROFILE_SELECT,
+    take: NICKNAME_SEARCH_LIMIT,
+    orderBy: { nickname: 'asc' },
+  });
+
+  return Promise.all(users.map((user) => enrichPublicUser({ user, requestUserID })));
 };
 
 // 특정 유저 프로필 조회
@@ -209,25 +299,7 @@ export const getUserProfile = async (params: GetUserProfileParams) => {
 
   if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
 
-  const [followerCount, followingCount, following] = await Promise.all([
-    prisma.follow.count({ where: { followingID: userID } }),
-    prisma.follow.count({ where: { followerID: userID } }),
-    prisma.follow.findUnique({
-      where: {
-        followerID_followingID: {
-          followerID: requestUserID,
-          followingID: userID,
-        },
-      },
-      select: { id: true },
-    }),
-  ]);
+  await assertNotBlocked(requestUserID, userID);
 
-  return {
-    ...user,
-    followerCount,
-    followingCount,
-    isFollowing: Boolean(following),
-    isMe: user.id === requestUserID,
-  };
+  return enrichPublicUser({ user, requestUserID });
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -5,6 +5,9 @@ import {
   USER_PUBLIC_PROFILE_SELECT,
   type GetMyProfileParams,
   type SearchUserByCodeParams,
+  type ToggleKnockPermissionParams,
+  type UpdateMyNicknameParams,
+  type UpdateMyProfileImageParams,
   type UpdateMyProfileParams,
 } from '../types/user.types.js';
 import { createError } from '../utils/createError.js';
@@ -42,6 +45,35 @@ export const updateMyProfile = async (params: UpdateMyProfileParams) => {
   return prisma.user.update({
     where: { id: userID },
     data,
+    select: USER_PROFILE_SELECT,
+  });
+};
+
+// 프로필 이미지만 수정
+export const updateMyProfileImage = async (params: UpdateMyProfileImageParams) => {
+  const { userID, profile } = params;
+  return updateMyProfile({ userID, profile });
+};
+
+// 닉네임만 수정
+export const updateMyNickname = async (params: UpdateMyNicknameParams) => {
+  const { userID, nickname } = params;
+  return updateMyProfile({ userID, nickname });
+};
+
+// 노크 허용 여부 토글
+export const toggleKnockPermission = async (params: ToggleKnockPermissionParams) => {
+  const { userID } = params;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userID },
+    select: { id: true, isKnocked: true },
+  });
+  if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
+
+  return prisma.user.update({
+    where: { id: userID },
+    data: { isKnocked: !user.isKnocked },
     select: USER_PROFILE_SELECT,
   });
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -6,11 +6,27 @@ import {
   type GetMyProfileParams,
   type SearchUserByCodeParams,
   type ToggleKnockPermissionParams,
+  type UpdateBrowsePublicSettingParams,
   type UpdateMyNicknameParams,
   type UpdateMyProfileImageParams,
   type UpdateMyProfileParams,
+  type UpdateRandomFeedSettingParams,
+  type UpdateRecommendEnabledSettingParams,
+  type UpdateRecommendPublicSettingParams,
 } from '../types/user.types.js';
 import { createError } from '../utils/createError.js';
+
+const BROWSE_DEPENDENT_RESET = {
+  isPublic: false,
+  isRecommendPublic: false,
+  isRecommendEnabled: false,
+} as const;
+
+const assertRandomFeedEnabled = (isRandomFeed: boolean) => {
+  if (!isRandomFeed) {
+    throw createError('랜덤피드 허용이 켜져 있어야 이 설정을 변경할 수 있습니다.', 400);
+  }
+};
 
 // 내 프로필 조회
 export const getMyProfile = async (params: GetMyProfileParams) => {
@@ -74,6 +90,76 @@ export const toggleKnockPermission = async (params: ToggleKnockPermissionParams)
   return prisma.user.update({
     where: { id: userID },
     data: { isKnocked: !user.isKnocked },
+    select: USER_PROFILE_SELECT,
+  });
+};
+
+// 랜덤피드 허용 여부 수정 (OFF 시 관련 설정 모두 OFF)
+export const updateRandomFeedSetting = async (params: UpdateRandomFeedSettingParams) => {
+  const { userID, isRandomFeed } = params;
+
+  const exists = await prisma.user.findUnique({ where: { id: userID }, select: { id: true } });
+  if (!exists) throw createError('사용자를 찾을 수 없습니다.', 404);
+
+  const data = isRandomFeed ? { isRandomFeed: true } : { isRandomFeed: false, ...BROWSE_DEPENDENT_RESET };
+
+  return prisma.user.update({
+    where: { id: userID },
+    data,
+    select: USER_PROFILE_SELECT,
+  });
+};
+
+// 둘러보기 공개 여부 수정
+export const updateBrowsePublicSetting = async (params: UpdateBrowsePublicSettingParams) => {
+  const { userID, isPublic } = params;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userID },
+    select: { id: true, isRandomFeed: true },
+  });
+  if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
+  if (isPublic) assertRandomFeedEnabled(user.isRandomFeed);
+
+  return prisma.user.update({
+    where: { id: userID },
+    data: { isPublic },
+    select: USER_PROFILE_SELECT,
+  });
+};
+
+// 추천친구 공개 여부 수정
+export const updateRecommendPublicSetting = async (params: UpdateRecommendPublicSettingParams) => {
+  const { userID, isRecommendPublic } = params;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userID },
+    select: { id: true, isRandomFeed: true },
+  });
+  if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
+  if (isRecommendPublic) assertRandomFeedEnabled(user.isRandomFeed);
+
+  return prisma.user.update({
+    where: { id: userID },
+    data: { isRecommendPublic },
+    select: USER_PROFILE_SELECT,
+  });
+};
+
+// 추천친구 알고리즘 허용 여부 수정
+export const updateRecommendEnabledSetting = async (params: UpdateRecommendEnabledSettingParams) => {
+  const { userID, isRecommendEnabled } = params;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userID },
+    select: { id: true, isRandomFeed: true },
+  });
+  if (!user) throw createError('사용자를 찾을 수 없습니다.', 404);
+  if (isRecommendEnabled) assertRandomFeedEnabled(user.isRandomFeed);
+
+  return prisma.user.update({
+    where: { id: userID },
+    data: { isRecommendEnabled },
     select: USER_PROFILE_SELECT,
   });
 };

--- a/src/types/block.types.ts
+++ b/src/types/block.types.ts
@@ -1,0 +1,4 @@
+export interface BlockUserParams {
+  blockerID: string;
+  blockedID: string;
+}

--- a/src/types/recommend.types.ts
+++ b/src/types/recommend.types.ts
@@ -1,0 +1,17 @@
+export const RECOMMEND_USER_SELECT = {
+  id: true,
+  nickname: true,
+  profile: true,
+  userCode: true,
+  isKnocked: true,
+} as const;
+
+export interface RecommendedFriend {
+  id: string;
+  nickname: string;
+  profile: string;
+  userCode: string;
+  isKnocked: boolean;
+  matchScore: number;
+  matchedCategories: string[];
+}

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -28,6 +28,35 @@ export interface ToggleKnockPermissionParams {
   userID: string;
 }
 
+// 랜덤피드 허용 여부 수정 파라미터
+export interface UpdateRandomFeedSettingParams {
+  userID: string;
+  isRandomFeed: boolean;
+}
+
+// 둘러보기 공개 여부 수정 파라미터
+export interface UpdateBrowsePublicSettingParams {
+  userID: string;
+  isPublic: boolean;
+}
+
+// 추천친구 공개 여부 수정 파라미터
+export interface UpdateRecommendPublicSettingParams {
+  userID: string;
+  isRecommendPublic: boolean;
+}
+
+// 추천친구 알고리즘 허용 여부 수정 파라미터
+export interface UpdateRecommendEnabledSettingParams {
+  userID: string;
+  isRecommendEnabled: boolean;
+}
+
+// 추천친구 조회 파라미터
+export interface GetRecommendedFriendsParams {
+  userID: string;
+}
+
 // 유저코드 검색 파라미터
 export interface SearchUserByCodeParams {
   userCode: string;
@@ -50,6 +79,10 @@ export const USER_PROFILE_SELECT = {
   userCode: true,
   isKnocked: true,
   isAgreed: true,
+  isRandomFeed: true,
+  isPublic: true,
+  isRecommendPublic: true,
+  isRecommendEnabled: true,
   createdAt: true,
   updatedAt: true,
 } as const;

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -63,6 +63,26 @@ export interface SearchUserByCodeParams {
   requestUserID: string;
 }
 
+// 닉네임 검색 파라미터
+export interface SearchUsersByNicknameParams {
+  nickname: string;
+  requestUserID: string;
+}
+
+// 공개 프로필 + 관계 정보 enrichment 파라미터
+export interface EnrichPublicUserParams {
+  user: {
+    id: string;
+    nickname: string;
+    profile: string;
+    userCode: string;
+    isKnocked: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  requestUserID: string;
+}
+
 // 특정 유저 프로필 조회 파라미터
 export interface GetUserProfileParams {
   userID: string;

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -11,6 +11,23 @@ export interface UpdateMyProfileParams {
   isKnocked?: boolean | undefined;
 }
 
+// 프로필 이미지만 수정 파라미터
+export interface UpdateMyProfileImageParams {
+  userID: string;
+  profile: string;
+}
+
+// 닉네임만 수정 파라미터
+export interface UpdateMyNicknameParams {
+  userID: string;
+  nickname: string;
+}
+
+// 노크 허용 여부 토글 파라미터
+export interface ToggleKnockPermissionParams {
+  userID: string;
+}
+
 // 유저코드 검색 파라미터
 export interface SearchUserByCodeParams {
   userCode: string;


### PR DESCRIPTION
## 🔗 관련 이슈

close #21

## 📌 작업 내용

- User 필드 추가 (isRandomFeed, isPublic, isRecommendPublic, isRecommendEnabled)
- Block 모델 및 팔로워 차단/차단해제 API 구현
- 프로필 수정 API (통합 / 이미지 / 닉네임 / 노크 토글)
- 둘러보기·추천친구 설정 API 4종 구현
- 추천친구 조회 API (버킷 카테고리 유사도 기반)
- 닉네임 기반 사용자 검색 API
- 유저코드 검색·프로필 조회·추천친구에 차단 관계 반영

> 배포 시 `npx prisma db push` 및 `npx prisma generate` 필요

## 🧪 테스트 내용

- API 테스트 완료
- 수정된 DB에 맞춰서 기존 API 명세서 일부 수정

## 💖 리뷰 요청사항 (선택사항)
- API 명세서에 맞춰서 테스트 진행하시면 됩니다.
- 수정된 DB는 DB 설계서 금방 반영할 예정입니다.
